### PR TITLE
Fix path computation for custom datasets

### DIFF
--- a/src/nli/training.py
+++ b/src/nli/training.py
@@ -468,7 +468,7 @@ def train(local_rank, args):
     for named_path in train_data_named_path:
         ind = named_path.find(':')
         name = named_path[:ind]
-        path = name[ind + 1:]
+        path = named_path[ind + 1:]
         if name in registered_path:
             d_list = common.load_jsonl(registered_path[name])
         else:
@@ -489,7 +489,7 @@ def train(local_rank, args):
     for named_path in eval_data_named_path:
         ind = named_path.find(':')
         name = named_path[:ind]
-        path = name[ind + 1:]
+        path = named_path[ind + 1:]
         if name in registered_path:
             d_list = common.load_jsonl(registered_path[name])
         else:


### PR DESCRIPTION
As written, the logic in `training.py` does not properly split on the `:` character for custom datasets specified by the `--train_data` or `--eval_data` command-line arguments. This pull request corrects this such that a custom dataset can be supplied as input.

Example use:

```
python ./src/nli/training.py \
    --model_class_name "distilbert" \
    -n 1 \
    -g 1 \
    --single_gpu \
    -nr 0 \
    --max_length 156 \
    --gradient_accumulation_steps 1 \
    --per_gpu_train_batch_size 16 \
    --per_gpu_eval_batch_size 16 \
    --save_prediction \
    --train_data train_filtered:./custom_datasets/train_filtered.jsonl \
    --train_weights 1 \
    --eval_data anli_r3_dev:none \
    --eval_frequency 2000 \
    --experiment_name "distilbert-run1"
```

Without this fix, it is not possible to read in the training data at `/custom_datasets/train_filtered.jsonl`.